### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -65,6 +65,19 @@ import {
 } from "@/components/ui/table";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
+// Helper function to safely validate URLs before using them in href/src attributes
+const isSafeUrl = (url?: string | null): boolean => {
+  if (!url) return false;
+
+  try {
+    const parsed = new URL(url, typeof window !== "undefined" ? window.location.origin : "http://localhost");
+    // Allow only http and https protocols to avoid javascript:, data:, etc.
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 // Helper function to get initials from a name
 const getInitials = (name: string) => {
   if (!name) return "U";
@@ -167,6 +180,7 @@ const DocumentOrActionItem = ({
   revalRef?: React.RefObject<HTMLInputElement>;
 }) => {
   const IconComponent = icon;
+  const safeUrl = url && isSafeUrl(url) ? url : undefined;
 
   return (
     <div className="mb-3 flex flex-col items-start gap-2 rounded-md border-[#334155] p-3 text-white sm:flex-row sm:items-center sm:justify-between">
@@ -177,14 +191,14 @@ const DocumentOrActionItem = ({
         <span className="text-sm font-medium text-white">{label}</span>
       </div>
       <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
-        {url && url !== "#" ? (
+        {safeUrl ? (
           <Button
             variant="outline"
             size="sm"
             asChild
             className="w-full sm:w-auto">
             <a
-              href={url}
+              href={safeUrl}
               download={isDownloadable}
               target="_blank"
               rel="noopener noreferrer">


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/15](https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/15)

Generally, to fix this kind of issue you ensure that any untrusted value used in an `href` (or other navigation-related attribute) is validated or sanitized before use. The core idea is to only allow URLs with safe schemes (`http:`, `https:`, maybe `mailto:`), and to treat anything else as invalid and not render it as a clickable link. You do not need to escape anything manually because React safely handles attributes; instead you restrict what values are allowed and fall back to a non-link state when a value is unsafe.

In this file, the best minimal fix is to introduce a small helper function, e.g. `isSafeUrl`, that receives a string and returns `true` only if it’s a reasonably safe URL (non-empty, parses as a URL, and has a whitelisted protocol). Then, inside `DocumentOrActionItem`, compute a `safeUrl` value based on `url`: if `url` is present and `isSafeUrl(url)` is true, use it; otherwise treat it as absent (so the component falls through to showing "Not Available" or to the `button` action path). This keeps all existing functionality (valid URLs still behave as before) while preventing potentially malicious values from ever being used as an `href`. Because you can only change this file, you should define `isSafeUrl` directly in `src/app/(app)/profile/page.tsx` near the top, after the imports or near `getInitials`. No new external dependencies are needed; use the standard `URL` constructor with a `try/catch` to validate and check the `protocol` property.

Concretely:
- Add a helper `const isSafeUrl = (url?: string | null) => boolean` that:
  - Returns `false` for falsy input.
  - Uses `new URL(url, window.location.origin)` in a `try/catch`.
  - Checks `parsed.protocol` is in a set like `["http:", "https:"]`.
- In `DocumentOrActionItem`, compute `const safeUrl = url && isSafeUrl(url) ? url : undefined;`.
- Replace the conditional `url && url !== "#"` with `safeUrl` and use `href={safeUrl}` in the `<a>` tag.
This ensures tainted input cannot produce a dangerous link even if the server fails to sanitize.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
