### PR TITLE
Potential fix for code scanning alert no. 11: Use of externally-controlled format string

### DIFF
--- a/src/services/profile-change-request.ts
+++ b/src/services/profile-change-request.ts
@@ -299,7 +299,8 @@ export async function denyProfileChangeRequest(
     });
   } catch (error) {
     console.error(
-      `Error denying profile change request ${requestId} (Admin SDK):`,
+      "Error denying profile change request (Admin SDK):",
+      requestId,
       error,
     );
     throw error;


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/11](https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/11)

In general, to fix externally-controlled format string issues with `console`/`util.format`, avoid passing tainted input as part of the format string (the first string argument). Instead, pass a constant format string and then pass untrusted data as subsequent arguments (for example, using `%s`), or pass separate arguments and let Node print them separated by spaces.

For this specific case, the simplest change that preserves functionality is to remove the template literal containing `requestId` from the first argument and instead pass `requestId` as a separate argument. That way, the first argument is a static string, and `requestId` cannot introduce format specifiers. Concretely, in `src/services/profile-change-request.ts`, lines 301–304 should be updated so that `console.error` is called with a constant message, then `requestId`, then `error`. No new imports or helper functions are required, and the log output remains clear (e.g., `"Error denying profile change request (Admin SDK): 12345 <Error ...>"`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
