### PR TITLE
Potential fix for code scanning alert no. 9: Use of externally-controlled format string

### DIFF
--- a/src/services/grades.ts
+++ b/src/services/grades.ts
@@ -308,7 +308,7 @@ export async function deleteStudentGrade(
   try {
     await adminDb.collection("grades").doc(gradeId).delete();
   } catch (error) {
-    console.error(`Error deleting grade ${gradeId}:`, error);
+    console.error("Error deleting grade %s:", gradeId, error);
     throw new Error("Failed to delete the grade.");
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/9](https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/9)

In general, the fix is to avoid using untrusted data as the format string argument to logging/formatting functions. Instead, use a constant format string and pass untrusted data as separate arguments corresponding to `%s` placeholders, or sanitize the untrusted data so it cannot be interpreted as a format specifier.

Here, the simplest, behavior-preserving fix is to change the `console.error` call in `deleteStudentGrade` so that the first argument is a constant string containing `%s` placeholders, and `gradeId` is passed as a separate argument. The `error` object should remain as a separate argument as well. Concretely, in `src/services/grades.ts` around line 311, replace:

```ts
console.error(`Error deleting grade ${gradeId}:`, error);
```

with:

```ts
console.error("Error deleting grade %s:", gradeId, error);
```

No new imports or helper methods are needed; we only adjust the logging call so the tainted `gradeId` is no longer part of the format string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
