### PR TITLE
Potential fix for code scanning alert no. 16: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -70,9 +70,19 @@ const isSafeUrl = (url?: string | null): boolean => {
   if (!url) return false;
 
   try {
-    const parsed = new URL(url, typeof window !== "undefined" ? window.location.origin : "http://localhost");
+    const baseOrigin =
+      typeof window !== "undefined" ? window.location.origin : "http://localhost";
+    const parsed = new URL(url, baseOrigin);
     // Allow only http and https protocols to avoid javascript:, data:, etc.
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+    // In the browser, additionally enforce same-origin to avoid navigating to arbitrary domains.
+    if (typeof window !== "undefined") {
+      return parsed.origin === window.location.origin;
+    }
+    // On the server, fall back to protocol-only validation since window is not available.
+    return true;
   } catch {
     return false;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/16](https://github.com/toxicbishop/KSSEM-College-ERP-System/security/code-scanning/16)

In general, to fix this class of issue you must ensure that any untrusted text that ends up being used in a URL-based sink (like `href` or `src`) is not only scheme-validated but also constrained to an expected, safe set of destinations, or otherwise encoded so it cannot execute script or break out of its context.

For this code, the best targeted fix without changing functionality is to tighten `isSafeUrl` so that:
- It still rejects non-`http`/`https` schemes (current behavior), and
- It additionally restricts URLs to the current origin (or another clearly defined safe origin), which is appropriate for things like ID-card and admission-letter links that should logically live on the same site or assets domain.

Since `isSafeUrl` is defined in the same file and already used to compute `safeUrl`, we can implement this entirely within `src/app/(app)/profile/page.tsx`. We will modify `isSafeUrl` (lines ~69–76) to:
- Parse the URL against the current `window.location.origin` as base as it already does.
- Return `false` unless the resulting `parsed.origin` matches `window.location.origin` when running in the browser.
  - For SSR (where `window` is not defined), we can conservatively allow any `http`/`https` URL based on the base `"http://localhost"` that is already used; server-rendered markup just contains the `href` string and cannot execute script by itself.

No other code needs to change, since everything consuming `safeUrl` is already branching on its truthiness.

Concretely:
- Edit the `isSafeUrl` function near the top of `src/app/(app)/profile/page.tsx`.
- Keep existing imports as-is; no new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
