### PR TITLE
fix: force patched postcss and uuid via pnpm overrides (CVE-2026-41305, CVE-2026-41907)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: '>=8.5.15'
+  uuid: '>=14.0.0'
+
 importers:
 
   .:
@@ -199,7 +203,7 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       postcss:
-        specifier: ^8.5.15
+        specifier: '>=8.5.15'
         version: 8.5.15
       tailwindcss:
         specifier: ^3.4.19
@@ -4342,20 +4346,20 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: '>=8.5.15'
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: '>=8.5.15'
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.15'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -4372,7 +4376,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: '>=8.5.15'
 
   postcss-selector-parser@6.1.4:
     resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
@@ -4380,10 +4384,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -5011,19 +5011,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -5833,7 +5822,7 @@ snapshots:
       node-fetch: 3.3.2
       partial-json: 0.1.7
       uri-templates: 0.2.0
-      uuid: 10.0.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - '@google-cloud/firestore'
       - bufferutil
@@ -8847,7 +8836,7 @@ snapshots:
 
   eventid@2.0.1:
     dependencies:
-      uuid: 8.3.2
+      uuid: 14.0.0
     optional: true
 
   express@4.22.2:
@@ -9121,7 +9110,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9178,7 +9167,7 @@ snapshots:
     dependencies:
       '@genkit-ai/ai': 1.37.0(@google-cloud/firestore@7.11.6)(firebase-admin@13.10.0)(firebase@12.14.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6)(firebase-admin@13.10.0)(firebase@12.14.0))
       '@genkit-ai/core': 1.37.0(@google-cloud/firestore@7.11.6)(firebase-admin@13.10.0)(firebase@12.14.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6)(firebase-admin@13.10.0)(firebase@12.14.0))
-      uuid: 10.0.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - '@google-cloud/firestore'
       - bufferutil
@@ -9300,7 +9289,7 @@ snapshots:
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.4
       retry-request: 7.0.2
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9333,7 +9322,7 @@ snapshots:
       google-auth-library: 9.15.1
       qs: 6.15.2
       url-template: 2.0.8
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9954,7 +9943,7 @@ snapshots:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
@@ -10190,12 +10179,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:
@@ -10833,7 +10816,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11030,12 +11013,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@10.0.0: {}
-
-  uuid@8.3.2:
-    optional: true
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,7 @@ allowBuilds:
   protobufjs: true
   sharp: true
   unrs-resolver: true
+
+overrides:
+  postcss: '>=8.5.15'
+  uuid: '>=14.0.0'


### PR DESCRIPTION
# Security Remediation 

## Result: 2 of 5 alerts fixed  | 3 alerts deferred 

Build passes cleanly: **34/34 pages** compiled, no errors.

---

## What Was Changed

### [pnpm-workspace.yaml](file:///d:/Code/Repo/College-ERP/pnpm-workspace.yaml) — `overrides` block added

```yaml
overrides:
  postcss: '>=8.5.15'
  uuid: '>=14.0.0'
```

This forces pnpm to resolve the patched versions for all transitive consumers, regenerating `pnpm-lock.yaml`.

---

## Alerts Fixed

| # | Alert | CVE | Before | After |
|---|-------|-----|--------|-------|
| #57 | PostCSS XSS via `</style>` | CVE-2026-41305 | `postcss@8.4.31` (via `next`) | `postcss@8.5.15`  |
| #60 | uuid buffer bounds check | CVE-2026-41907 | `uuid@8.3.2` (via `@google-cloud/logging`) | `uuid@14.0.0`  |

---

## Alerts Deferred  — Blocked on genkit update

| # | Alert | CVE | Why deferred |
|---|-------|-----|--------------|
| #58 | Prometheus exporter crash (`@opentelemetry/sdk-node`) | CVE-2026-44902 | Fix requires `sdk-node@≥0.217.0` which depends on `@opentelemetry/core@2.x` |
| #59 | Prometheus exporter crash (`@opentelemetry/auto-instrumentations-node`) | CVE-2026-44902 | Same — fix version requires `core@2.x` |
| #61 | OTel Core unbounded baggage memory | CVE-2026-54285 | Fix is `@opentelemetry/core@2.8.0`, but genkit@1.37 calls `getEnv()` which was removed in `core@2.0` |

### Root Cause of Deferral

`genkit@1.37.0` (latest) internally uses `@opentelemetry/core@^1.x` and calls `getEnv()`, an API that was **removed in `@opentelemetry/core@2.0`**. Forcing `core@>=2.8.0` via override causes a runtime crash:

```
TypeError: (0 , core_1.getEnv) is not a function
Error: Failed to collect page data for /api/genkit/[...slug]
```

All three OTel fixes require `core@2.x`, so they cannot be applied until genkit ships support for the v2 OpenTelemetry JS SDK.

## What to Watch For

- **Monitor [genkit releases](https://github.com/firebase/genkit/releases)** for `@opentelemetry/core@2.x` support. Once genkit ships it, re-add to `pnpm-workspace.yaml`:
  ```yaml
  overrides:
    '@opentelemetry/sdk-node': '>=0.217.0'
    '@opentelemetry/auto-instrumentations-node': '>=0.75.0'
    '@opentelemetry/core': '>=2.8.0'
  ```
- The two `deprecated` warnings (`recharts@2.x`, `@genkit-ai/googleai`) are unrelated to security but worth addressing in a future cleanup.
