### PR TITLE
CI: Fix GHCR manifest resolution and missing build-time env vars

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,8 +5,6 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["master"]
-  release:
-    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -38,8 +36,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=long
 
       - name: Build and push Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY . .
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV GOOGLE_CLOUD_PROJECT=dummy
+ENV GCLOUD_PROJECT=dummy
+ENV FIREBASE_CONFIG='{"projectId":"dummy"}'
 
 RUN pnpm run build
 


### PR DESCRIPTION
## Overview
This PR resolves the fatal GHCR manifest/token fetch error that was causing the `docker-publish.yml` GitHub Actions workflow to fail during the image push step. 

## Fixes Implemented

### 1. Workflow Publishing Triggers
- Removed the `release` trigger from `.github/workflows/docker-publish.yml`. Publishing will now only occur reliably on `push` and `pull_request` to `master`.

### 2. Deterministic Image Tags
- Simplified the `docker/metadata-action` tags configuration. 
- Removed event/ref-derived tags (like `type=ref,event=branch`) which were causing tag and manifest resolution issues in the GitHub Container Registry on release events.
- Enforced a deterministic `raw,value=latest` tag for the default branch and the standard `sha` tag.

### 3. Dockerfile Build-time Hardening
- Added safe, dummy environment variables (`GOOGLE_CLOUD_PROJECT`, `FIREBASE_CONFIG`, etc.) inside the `Dockerfile` directly preceding `RUN pnpm run build`. 
- This prevents the Next.js static generation from throwing repeated "Unable to detect a Project Id" errors when attempting server-side Firestore fetches during the Docker build phase.