### PR TITLE
security: fix CodeQL js/xss-through-dom in profile page img src (CWE-79)

### DIFF
--- a/src/lib/sanitize-url.ts
+++ b/src/lib/sanitize-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Ensures a URL used as an <img> src is a safe scheme.
+ * Allows: https://, http://, and data:image/... only.
+ * Rejects javascript:, data:text/html, blob:, etc. to prevent XSS
+ * (CodeQL js/xss-through-dom / CWE-79).
+ */
+export function sanitizeImageUrl(url: string | null | undefined): string {
+  if (!url) return '';
+  const trimmed = url.trim();
+  if (
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('http://') ||
+    /^data:image\/(png|jpe?g|gif|webp|svg\+xml|bmp);base64,/i.test(trimmed)
+  ) {
+    return trimmed;
+  }
+  // Reject anything else (javascript:, data:text/html, blob: from unknown origins, etc.)
+  return '';
+}

--- a/src/pages/(app)/profile/page.tsx
+++ b/src/pages/(app)/profile/page.tsx
@@ -20,6 +20,7 @@ import type {
 import { fetchStudentClassrooms, fetchClassmates } from "../classrooms/actions";
 
 import sanitizeHtml from 'sanitize-html';
+import { sanitizeImageUrl } from '@/lib/sanitize-url';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -1088,12 +1089,12 @@ function ProfileDetailsLoader() {
                   : profile.uploadedSignatureUrl
               ) ? (
                 <img
-                  src={
+                  src={sanitizeImageUrl(
                     isEditMode &&
                     typeof editableProfile.uploadedSignatureUrl === "string"
                       ? editableProfile.uploadedSignatureUrl
-                      : profile.uploadedSignatureUrl!
-                  }
+                      : profile.uploadedSignatureUrl
+                  )}
                   alt="Uploaded Signature"
                   width={200}
                   height={80}


### PR DESCRIPTION
- Add src/lib/sanitize-url.ts with sanitizeImageUrl() that whitelists only https://, http://, and data:image/* base64 URIs
- Apply sanitizeImageUrl() to the uploadedSignatureUrl img src to prevent javascript: and data:text/html URI injection
- Move helper to a shared utility for reuse across components